### PR TITLE
Add Content-Security-Policy header to next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,18 @@
 import type { NextConfig } from "next";
 
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://cdn.provesrc.com",
+  "connect-src 'self' https://formspree.io https://www.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com https://*.provesrc.com",
+  "img-src 'self' data: https:",
+  "style-src 'self' 'unsafe-inline'",
+  "font-src 'self' data:",
+  "base-uri 'self'",
+  "form-action 'self' https://formspree.io",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+].join("; ");
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   poweredByHeader: false,
@@ -15,6 +28,7 @@ const nextConfig: NextConfig = {
       {
         source: "/(.*)",
         headers: [
+          { key: "Content-Security-Policy", value: contentSecurityPolicy },
           { key: "X-Frame-Options", value: "DENY" },
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },


### PR DESCRIPTION
## Summary
- add a route-wide `Content-Security-Policy` header in `next.config.ts`
- allow the current GA and ProveSource script usage plus existing Formspree submissions
- keep the existing security headers intact

## Validation
- `npm run typecheck`
- `npm run build`
- `npm run lint`

Closes #7
Refs DOT-64